### PR TITLE
(hackathon) Change search styling

### DIFF
--- a/assets/json/offline-search-index.json
+++ b/assets/json/offline-search-index.json
@@ -1,7 +1,5 @@
 {{- $.Scratch.Add "offline-search-index" slice -}}
 {{- range where .Site.AllPages ".Params.exclude_search" "!=" true -}}
-{{/* We have to apply `htmlUnescape` again after `truncate` because `truncate` applies `html.EscapeString` if the argument is not HTML. */}}
-{{/* Indvidual taxonomies can be added in the next line by add '"taxonomy-name" (.Params.taxonomy-name | default "")' to the dict (as seen for categories and tags). */}}
-{{- $.Scratch.Add "offline-search-index" (dict "ref" .RelPermalink "title" .Title "categories" (.Params.categories | default "") "tags" (.Params.tags | default "") "description" (.Description | default "") "body" (.Plain | htmlUnescape) "excerpt" ((.Description | default .Plain) | htmlUnescape | truncate (.Site.Params.offlineSearchSummaryLength | default 70) | htmlUnescape)) -}}
+{{- $.Scratch.Add "offline-search-index" (dict "ref" .RelPermalink "title" .Title "categories" (.Params.categories | default "") "tags" (.Params.tags | default "") "description" .Params.description  "body" .Plain "excerpt" (.Summary | truncate 200) "last_mod" .Lastmod) -}}
 {{- end -}}
 {{- $.Scratch.Get "offline-search-index" | jsonify -}}

--- a/assets/scss/_boxes.scss
+++ b/assets/scss/_boxes.scss
@@ -34,7 +34,7 @@
     @include link-variant("#{$parent}--#{$color-name} p > a", $link-color, $link-hover-color, false);
 
     @if $enable-gradients {
-        @include bg-gradient-variant("#{$parent}--1#{$color-name}#{$parent}--gradient", $color-value,true);
+        @include bg-gradient-variant("#{$parent}--1#{$color-name}#{$parent}--gradient", $color-value);
     }
 }
 

--- a/assets/scss/_tink_search.scss
+++ b/assets/scss/_tink_search.scss
@@ -1,0 +1,67 @@
+/*
+
+Modifications made to docsy search styling for tink-ab.
+
+*/
+
+.popover {
+    max-width: 750px !important; /* Max Width of the popover (depending on the container!) */
+}
+
+.popover.offline-search-result {
+    .card {
+        margin-bottom: 10px;
+
+        .card-header {
+            padding: 0.5rem 1rem 0.5rem;
+            font-weight: normal;
+
+            .last-mod {
+                font-size: 9pt;
+                color: #888;
+                float: right;
+            }
+
+            .card-header-context {
+                clear: both;
+
+                .breadcrumbs {
+                    font-size: 9pt;
+                    float: left;
+                    width: 55%;
+
+                    & a {
+                        color: #444;
+                    }
+
+                    & a:hover {
+                        color: #999;
+                    }
+                }
+
+                .tags {
+                    font-size: 8pt;
+                    float: left;
+                    width: 45%;
+                    text-align: right;
+
+                    .tag {
+                        font-size: 9pt;
+                        float: right;
+                        display: block;
+                        margin: 0 3px
+                    }
+                }
+            }
+        }
+
+        .card-text {
+            &.description {
+                margin: -8px 0 5px;
+                font-style: italic;
+                color: #222;
+                font-size: 9pt;
+            }
+        }
+    }
+}

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -63,3 +63,4 @@ footer {
 
 @import "rtl/main";
 @import "styles_project";
+@import "tink_search";


### PR DESCRIPTION
Some small tweaks to the offline-search functionality, presented at the last hackathon:

* Add `tags` to search indexing
* Add `last_mod`, `description`, `tags` to search result cards.
* Improve `excerpt` output, swallowing HTML entities.

**Before:**
<img width="250px" src="https://user-images.githubusercontent.com/5781397/160299478-6a26a85a-64a1-42a7-8487-4b963fd01247.png">

**After:**
<img  alt="After screenshot" src="https://user-images.githubusercontent.com/5781397/160299487-f93fd823-5d84-47e6-85d5-cf6df022639f.png">

n.b. the last upstream merge was mostly working, but giving an error on SCSS-compilation. Fixed by removing the third argument, but this change was later reverted (google/docsy #875). It might be worth trying another upstream merge, as that worked for me.